### PR TITLE
Fixed test on query and bind

### DIFF
--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -1,5 +1,5 @@
 /* basex-node test interface using mocha
- * 
+ *
  */
 
 var basex = require('../index.js');
@@ -152,7 +152,7 @@ describe('Send a xquery and iterate over the result items', function() {
 		should.not.exist(err);
 	});
 	it('It should return an array', function() {
-		reply.result.should.be.an.instanceof(Array);
+		reply.result.should.be.an.Array;
 	});
 });
 
@@ -177,7 +177,7 @@ describe('create query and bind ', function() {
 		should.not.exist(err);
 	});
 	it('It should return a string', function() {
-		reply.result.should.be.a('string');
+		reply.result.should.be.a.String
 	});
 });
 


### PR DESCRIPTION
Hello,

I just installed basex-node and ran the tests and noticed the type check for string in 'query and bind' was failing. 

It was a simple syntax fix. 

I also converted the array check to use the short cut syntax while I was there.

Best,
-J
